### PR TITLE
use trim instead of replace

### DIFF
--- a/random-reviewer-picker/main.js
+++ b/random-reviewer-picker/main.js
@@ -9,7 +9,7 @@ function getInputs() {
   const reviewerList = core
     .getInput("reviewer_list")
     .split(",")
-    .map(i => i.replace(" ", ""));
+    .map(i => i.trim());
   const reviewerAmount = parseInt(core.getInput("reviewer_amount"));
   const maintainerList = core
     .getInput("maintainer_list")


### PR DESCRIPTION
`String.replace(" ", ...) only replaces the first occurrence. `String.trim()` gets rid of all trailing and leading spaces.