### PR TITLE
Fix for actions being stuck in queued after GH actions outage

### DIFF
--- a/prevent-concurrent-deploy/action.yml
+++ b/prevent-concurrent-deploy/action.yml
@@ -5,6 +5,9 @@ inputs:
   GITHUB_TOKEN:
     description: "A valid token for listing workflows"
     required: true
+  SKIP_QUEUED_ACTIONS:
+    description: "Ignore queued actions (default false)"
+    required: false
 runs:
   using: "node12"
   main: "main.js"


### PR DESCRIPTION
Last Monday during a Github outage, some actions were being scheduled but never ran.
When using the prevent-concurrent-job action, the result of the job can stay blocked by these actions (which cannot be cancelled).
These actions are reported as "queued" by the Github API.

This PR adds a SKIP_QUEUED_ACTIONS optional input, which will ignore queued actions when set to "true". This can be used until the issue is resolved (either by github, or the action beeing too old).