### PR TITLE
Make maintainers optional for FE repos

### DIFF
--- a/random-reviewer-picker/main.js
+++ b/random-reviewer-picker/main.js
@@ -61,6 +61,8 @@ async function isUserBusy(octokit, userHandle) {
  * then randomly pick the requested amount of users
  **/
 async function pickUsers(userList, pickAmount, removeBusy, prOwner, octokit) {
+  if (pickAmount === 0) return
+
   const pickedUsers = [];
   let filteredList = [];
 
@@ -87,7 +89,7 @@ async function pickUsers(userList, pickAmount, removeBusy, prOwner, octokit) {
 
 // This allow to have maintainers in the reviewer list. If they are already picked, we can make
 // a reviewerList without them
-function excludePickedMaintainer(userList, pickedMaintainers){
+function excludePickedMaintainer(userList, pickedMaintainers) {
   return difference(userList, pickedMaintainers);
 }
 
@@ -99,7 +101,7 @@ async function run() {
   const actionEvents = require(process.env.GITHUB_EVENT_PATH);
 
   const isDraft = actionEvents.pull_request.draft;
-  if(isDraft === true){
+  if (isDraft === true) {
     core.info("Ignoring Draft PR");
     return;
   }
@@ -148,8 +150,7 @@ async function run() {
       skipBusy,
       prOwner.login,
       octokit
-    );
-
+    ) || [];
     // Reviewers:
     const reviewers = await pickUsers(
       excludePickedMaintainer(reviewerList, maintainers),


### PR DESCRIPTION
Ticket: https://github.com/wunderflats/website/issues/1840 

In website, LLD and CRM we don't use `maintainers`, and we've noticed that the random selection is not really random and it might have something to do with the fact that we have duplicated `reviewersList` and `maintainersList`. In this PR I added the condition to take into account the `maintainersAmount`, which I would set to 0 in all three repositories along with removing the `maintainersList`.

Webiste PR:
- https://github.com/wunderflats/website/pull/1855

Website Assign Reviewers pipeline using the updated action => 
https://github.com/wunderflats/website/actions/runs/3488890774/jobs/5838281150

❓ I'm not sure if that's the right approach to have this merged to master, maybe we should use different branches for API vs frontend then 🤔 
❓ I wonder if we need to use the custom script if we don't need the maintainers logic for FE repos? Are we able to use Github settings for that? More context here: https://www.notion.so/wunderflats/Random-reviewers-not-really-random-2c6d07686d644664a89e7394b642640d
