### PR TITLE
cancel-if-not-latest: improve logging by using core.info intead of core.debug

### DIFF
--- a/cancel-if-not-latest/src/index.ts
+++ b/cancel-if-not-latest/src/index.ts
@@ -23,8 +23,8 @@ async function run() {
   });
   const latestCommitSha = latestCommit.data.sha;
 
-  core.debug(`Current commit SHA: ${thisCommitSha}`);
-  core.debug(`Latest commit SHA: ${latestCommitSha}`);
+  core.info(`Current commit SHA: ${thisCommitSha}`);
+  core.info(`Latest commit SHA: ${latestCommitSha}`);
 
   if (thisCommitSha !== latestCommitSha) {
     core.error(


### PR DESCRIPTION
Messages from `core.debug()` are hidden by default. I'd like to see the SHAs compared by this action.

Change:

- change `core.debug()` to `core.info()`