### PR TITLE
cancel-if-not-latest: disallow only re-runs

### DIFF
--- a/cancel-if-not-latest/action.yml
+++ b/cancel-if-not-latest/action.yml
@@ -1,7 +1,7 @@
 name: "cancel-if-not-latest"
 description: "Cancel a push workflow if it's not triggered by the latest commit of its branch"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 inputs:
   GITHUB_TOKEN:

--- a/cancel-if-not-latest/dist/index.js
+++ b/cancel-if-not-latest/dist/index.js
@@ -9593,6 +9593,9 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_github__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(2186);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var node_process__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(7742);
+/* harmony import */ var node_process__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__nccwpck_require__.n(node_process__WEBPACK_IMPORTED_MODULE_2__);
+
 
 
 const token = _actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput("GITHUB_TOKEN", { required: true });
@@ -9611,20 +9614,23 @@ async function run() {
         ref: _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.ref,
     });
     const latestCommitSha = latestCommit.data.sha;
+    const attempt = node_process__WEBPACK_IMPORTED_MODULE_2__.env.GITHUB_RUN_ATTEMPT;
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`Current commit SHA: ${thisCommitSha}`);
     _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`Latest commit SHA: ${latestCommitSha}`);
-    if (thisCommitSha !== latestCommitSha) {
-        _actions_core__WEBPACK_IMPORTED_MODULE_1__.error("This workflow run was cancelled because it tried to run on a commit that is not the latest.");
-        const { runId } = _actions_github__WEBPACK_IMPORTED_MODULE_0__.context;
-        await octokit.rest.actions.cancelWorkflowRun({
-            owner,
-            repo,
-            run_id: runId,
-        });
-    }
-    else {
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.info(`Attempt: ${attempt}`);
+    const isLatestCommit = thisCommitSha === latestCommitSha;
+    if (isLatestCommit) {
         _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("All good!");
+        return;
     }
+    const isFirstAttempt = attempt === "1";
+    if (isFirstAttempt) {
+        // Someone has made a new commit in the meantime, but this is still the first attempt of this workflow run
+        _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("All good!");
+        return;
+    }
+    const message = "This workflow run is not the latest commit on this branch";
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.setFailed(message);
 }
 
 __webpack_async_result__();
@@ -9686,6 +9692,13 @@ module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("https");
 /***/ ((module) => {
 
 module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("net");
+
+/***/ }),
+
+/***/ 7742:
+/***/ ((module) => {
+
+module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:process");
 
 /***/ }),
 

--- a/cancel-if-not-latest/package.json
+++ b/cancel-if-not-latest/package.json
@@ -13,6 +13,7 @@
     },
     "devDependencies": {
         "@octokit/webhooks-definitions": "3.67.3",
+        "@types/node": "20.8.8",
         "@vercel/ncc": "0.36.1",
         "typescript": "5.1.6"
     }

--- a/cancel-if-not-latest/yarn.lock
+++ b/cancel-if-not-latest/yarn.lock
@@ -118,6 +118,13 @@
   resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.67.3.tgz#d2a905a90b04af8111982d0c13658a49fc4eecb9"
   integrity sha512-do4Z1r2OVhuI0ihJhQ8Hg+yPWnBYEBNuFNCrvtPKoYT1w81jD7pBXgGe86lYuuNirkDHb0Nxt+zt4O5GiFJfgA==
 
+"@types/node@20.8.8":
+  version "20.8.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.8.tgz#adee050b422061ad5255fc38ff71b2bb96ea2a0e"
+  integrity sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==
+  dependencies:
+    undici-types "~5.25.1"
+
 "@vercel/ncc@0.36.1":
   version "0.36.1"
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.36.1.tgz#d4c01fdbbe909d128d1bf11c7f8b5431654c5b95"
@@ -166,6 +173,11 @@ typescript@5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+
+undici-types@~5.25.1:
+  version "5.25.3"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.25.3.tgz#e044115914c85f0bcbb229f346ab739f064998c3"
+  integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
# Description

We realised that when commits are queued for deployment, our jobs fail too early i.e. already on their first attempt.

This change should fix that. (DEV-11369)

# Other changes

- On failure condition, the action simply fails (instead of cancelling the workflow run).
- Use Node 20 (Node 16 is deprecated).

Test that it fails when it's not the latest commit (note that it recognizes the attempt counter correctly):

<img width="1661" alt="Screenshot 2023-10-25 at 18 13 14" src="https://github.com/wunderflats/actions/assets/6202537/26148905-d389-487f-b095-ac2249c035d4">

