### PR TITLE
Expose runAttempt for test-dashboard

### DIFF
--- a/upload-to-test-dashboard/dist/index.js
+++ b/upload-to-test-dashboard/dist/index.js
@@ -8834,15 +8834,16 @@ var env_var_default = /*#__PURE__*/__nccwpck_require__.n(env_var);
 
 
 /* harmony default export */ const config = ({
-  apiUrl: env_var_default().get('INPUT_API_URL').required().asString(),
-  repository: env_var_default().get('INPUT_REPOSITORY').required().asString(),
-  branch: env_var_default().get('INPUT_BRANCH').required().asString(),
-  testSuite: env_var_default().get('INPUT_TEST_SUITE').required().asString(),
-  testFileType: env_var_default().get('INPUT_TEST_FILE_TYPE').required().asString(),
-  commitHash: env_var_default().get('INPUT_COMMIT_HASH').required().asString(),
-  jobId: env_var_default().get('INPUT_JOB_ID').required().asString(),
-  files: env_var_default().get('INPUT_FILES').required().asString(),
-  pushToken: env_var_default().get('INPUT_DASHBOARD_PUSH_TOKEN').required().asString(),
+  apiUrl: env_var_default().get("INPUT_API_URL").required().asString(),
+  repository: env_var_default().get("INPUT_REPOSITORY").required().asString(),
+  branch: env_var_default().get("INPUT_BRANCH").required().asString(),
+  testSuite: env_var_default().get("INPUT_TEST_SUITE").required().asString(),
+  testFileType: env_var_default().get("INPUT_TEST_FILE_TYPE").required().asString(),
+  commitHash: env_var_default().get("INPUT_COMMIT_HASH").required().asString(),
+  jobId: env_var_default().get("INPUT_JOB_ID").required().asString(),
+  files: env_var_default().get("INPUT_FILES").required().asString(),
+  runAttempt: env_var_default().get("GITHUB_RUN_ATTEMPT").asString(),
+  pushToken: env_var_default().get("INPUT_DASHBOARD_PUSH_TOKEN").required().asString(),
 });
 
 ;// CONCATENATED MODULE: ./src/index.js
@@ -8863,6 +8864,7 @@ function getUploadUrl() {
     commitHash: config.commitHash,
     jobId: config.jobId,
     token: config.pushToken,
+    runAttempt: config.runAttempt,
   });
 
   const { apiUrl, repository, branch } = config;
@@ -8949,6 +8951,7 @@ function getConfig() {
     `  Commit hash: ${source.dim(config.commitHash)}`,
     `  Job ID: ${source.dim(config.jobId)}`,
     `  Files: ${source.dim(config.files)}`,
+    `  Run Attempt: ${source.dim(config.runAttempt)}`,
   ];
 }
 

--- a/upload-to-test-dashboard/src/config.js
+++ b/upload-to-test-dashboard/src/config.js
@@ -1,13 +1,14 @@
 import env from "env-var";
 
 export default {
-  apiUrl: env.get('INPUT_API_URL').required().asString(),
-  repository: env.get('INPUT_REPOSITORY').required().asString(),
-  branch: env.get('INPUT_BRANCH').required().asString(),
-  testSuite: env.get('INPUT_TEST_SUITE').required().asString(),
-  testFileType: env.get('INPUT_TEST_FILE_TYPE').required().asString(),
-  commitHash: env.get('INPUT_COMMIT_HASH').required().asString(),
-  jobId: env.get('INPUT_JOB_ID').required().asString(),
-  files: env.get('INPUT_FILES').required().asString(),
-  pushToken: env.get('INPUT_DASHBOARD_PUSH_TOKEN').required().asString(),
+  apiUrl: env.get("INPUT_API_URL").required().asString(),
+  repository: env.get("INPUT_REPOSITORY").required().asString(),
+  branch: env.get("INPUT_BRANCH").required().asString(),
+  testSuite: env.get("INPUT_TEST_SUITE").required().asString(),
+  testFileType: env.get("INPUT_TEST_FILE_TYPE").required().asString(),
+  commitHash: env.get("INPUT_COMMIT_HASH").required().asString(),
+  jobId: env.get("INPUT_JOB_ID").required().asString(),
+  files: env.get("INPUT_FILES").required().asString(),
+  runAttempt: env.get("GITHUB_RUN_ATTEMPT").asString(),
+  pushToken: env.get("INPUT_DASHBOARD_PUSH_TOKEN").required().asString(),
 };

--- a/upload-to-test-dashboard/src/index.js
+++ b/upload-to-test-dashboard/src/index.js
@@ -15,6 +15,7 @@ function getUploadUrl() {
     commitHash: config.commitHash,
     jobId: config.jobId,
     token: config.pushToken,
+    runAttempt: config.runAttempt,
   });
 
   const { apiUrl, repository, branch } = config;
@@ -101,6 +102,7 @@ function getConfig() {
     `  Commit hash: ${chalk.dim(config.commitHash)}`,
     `  Job ID: ${chalk.dim(config.jobId)}`,
     `  Files: ${chalk.dim(config.files)}`,
+    `  Run Attempt: ${chalk.dim(config.runAttempt)}`,
   ];
 }
 


### PR DESCRIPTION
Once again, this is an attempt to expose `runAttempt` env var to the test-dashboard (parser). This time I didn't convert the code to typescript, as that fails execution not being able to decide on modules, requires, and imports...

I also modified my test PR in API to use this branch for uploads not in a fake step, but in real jobs:
- WDIO tests till take the action code from master, as they use their own master.yaml workflow (?) https://github.com/wunderflats/api/actions/runs/8061597105/job/22023661210
- API mocha successfully ran on the first attempt: https://github.com/wunderflats/api/actions/runs/8061597105/job/22023652615
- API jest 2 ran on the second attempt only: https://github.com/wunderflats/api/actions/runs/8061597105/job/22023652856

P.S. In congif.js only the new runAttempt line was added. The other changes are automatically replaced single-quotes.
