### PR TITLE
Improve testing images bulk cleanup

### DIFF
--- a/remove-testing-images/dist/index.js
+++ b/remove-testing-images/dist/index.js
@@ -30676,6 +30676,7 @@ async function run() {
             return removeTestingImage(testingImageId);
         }
         if (bulkCleanup) {
+            // Cleanup images older than 2 months
             await cleanupUnneededTestingImages();
         }
     }
@@ -30715,14 +30716,8 @@ async function cleanupUnneededTestingImages() {
     })) {
         const testingImages = response.data;
         for (const image of testingImages) {
-            const imageTags = image.metadata.container.tags;
-            const isUnnecessaryImageWithHashTag = imageTags.length === 1 &&
-                imageTags[0].length === 40 &&
-                /^[A-F0-9]+$/i.test(imageTags[0]); // Hexadecimal check
-            const isOldImage = (0,date_fns__WEBPACK_IMPORTED_MODULE_2__.isBefore)((0,date_fns__WEBPACK_IMPORTED_MODULE_2__.parseISO)(image.created_at), (0,date_fns__WEBPACK_IMPORTED_MODULE_2__.subMonths)(new Date(), 3));
-            if (imageTags.length == 0 ||
-                isUnnecessaryImageWithHashTag ||
-                isOldImage) {
+            const isOldImage = (0,date_fns__WEBPACK_IMPORTED_MODULE_2__.isBefore)((0,date_fns__WEBPACK_IMPORTED_MODULE_2__.parseISO)(image.updated_at), (0,date_fns__WEBPACK_IMPORTED_MODULE_2__.subMonths)(new Date(), 2));
+            if (isOldImage) {
                 imagesToBeDeleted.push(image.id);
             }
         }

--- a/remove-testing-images/src/index.ts
+++ b/remove-testing-images/src/index.ts
@@ -43,6 +43,7 @@ async function run() {
     }
 
     if (bulkCleanup) {
+      // Cleanup images older than 2 months
       await cleanupUnneededTestingImages();
     }
   } catch (error) {
@@ -98,23 +99,12 @@ async function cleanupUnneededTestingImages() {
   )) {
     const testingImages = response.data;
     for (const image of testingImages) {
-      const imageTags = image.metadata.container.tags;
-
-      const isUnnecessaryImageWithHashTag =
-        imageTags.length === 1 &&
-        imageTags[0].length === 40 &&
-        /^[A-F0-9]+$/i.test(imageTags[0]); // Hexadecimal check
-
       const isOldImage = isBefore(
-        parseISO(image.created_at),
-        subMonths(new Date(), 3)
+        parseISO(image.updated_at),
+        subMonths(new Date(), 2)
       );
 
-      if (
-        imageTags.length == 0 ||
-        isUnnecessaryImageWithHashTag ||
-        isOldImage
-      ) {
+      if (isOldImage) {
         imagesToBeDeleted.push(image.id);
       }
     }


### PR DESCRIPTION
The `remove-testing-images` is not working correctly for the bulk cleanup and removing in-use layers, I changed the condition so the cleanup only removes the images older than 2 months. This way we can have a simple and safe cleanup.