### PR TITLE
Add a workflow to update MongoDB image

### DIFF
--- a/.github/workflows/update-mongo-image.yml
+++ b/.github/workflows/update-mongo-image.yml
@@ -1,10 +1,26 @@
 name: Update MongoDB Docker Image
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * 2" # Every Tuesday at 10 AM
 
 jobs:
   update-mongo-image:
-    runs-on: ubuntu-latest
+    name: Update MongoDB Image
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull MongoDB Image
+        run: docker pull mongo:8.0
+      - name: Tag and Push MongoDB Image to GHCR
+        run: |
+          docker tag mongo:8.0 ghcr.io/${{ github.repository_owner }}/mongo-image:8.0
+          docker push ghcr.io/${{ github.repository_owner }}/mongo-image:8.0


### PR DESCRIPTION
This PR adds a scheduled and manual workflow to pull the MongoDB docker image and push it to a new and public GitHub Container Package called `mongo-image` (linked to this repo).

Later we can use this image for some of our repos.