### PR TITLE
ci: publish mongo-image:8.0-rs replica-set variant

### DIFF
--- a/.github/workflows/update-mongo-image.yml
+++ b/.github/workflows/update-mongo-image.yml
@@ -24,3 +24,7 @@ jobs:
         run: |
           docker tag mongo:8.0 ghcr.io/${{ github.repository_owner }}/mongo-image:8.0
           docker push ghcr.io/${{ github.repository_owner }}/mongo-image:8.0
+      - name: Build and Push Replica-Set Variant to GHCR
+        run: |
+          docker build -t ghcr.io/${{ github.repository_owner }}/mongo-image:8.0-rs docker/mongo-rs
+          docker push ghcr.io/${{ github.repository_owner }}/mongo-image:8.0-rs

--- a/.github/workflows/update-mongo-image.yml
+++ b/.github/workflows/update-mongo-image.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       packages: write
     steps:
+      - uses: actions/checkout@v6
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/docker/mongo-rs/Dockerfile
+++ b/docker/mongo-rs/Dockerfile
@@ -1,0 +1,6 @@
+FROM mongo:8.0
+
+# Bake replica-set mode into the default command so consumers can use this
+# image directly as a GitHub Actions `services:` container. The services
+# block has no `command:` field, so flags must live in the image itself.
+CMD ["mongod", "--replSet", "rs", "--bind_ip_all"]


### PR DESCRIPTION
## Summary

- Adds a new GHCR tag `ghcr.io/wunderflats/mongo-image:8.0-rs` that boots in single-node replica-set mode out of the box (`CMD ["mongod", "--replSet", "rs", "--bind_ip_all"]`).
- Built from a tiny `docker/mongo-rs/Dockerfile` that re-bases `mongo:8.0`. No changes to the existing `:8.0` tag.

## Why

GitHub Actions `services:` blocks have no `command:` field and no clean way to pass CMD args. Consumers that need Mongo with `--replSet rs` (api/landlord-dashboard tests covering multi-document transactions, e.g. `shortlists/repository.ts`) currently rely on `supercharge/mongodb-github-action@1.12.1`, which is a Docker-based action that itself pulls `docker:latest` from Docker Hub at job-setup time. That has been timing out intermittently and failing CI before any of our own steps run.

Once this image is published, those workflows can swap the supercharge action for a plain `services:` block pointing at `:8.0-rs`. Diagnosis write-up: [MongoDB action CI failures: Docker Hub timeout, not GHCR](https://app.notion.com/p/37bc423332128186b218d1ce530a19de).

## Test plan

- [x] Manually trigger the workflow via `workflow_dispatch` and confirm both `:8.0` and `:8.0-rs` are pushed to GHCR.
- [ ] `docker pull ghcr.io/wunderflats/mongo-image:8.0-rs` locally, run it, and verify `mongod` starts with `--replSet rs` (visible in the container logs).
- [ ] Connect with `mongosh` and confirm `rs.status()` reports `NOT YET INITIALIZED` (expected — callers still need to run `rs.initiate()` against the running container).
- [ ] Wait for the next scheduled run on Tuesday at 10 AM and confirm both tags are refreshed.

## Follow-ups (not in this PR)

- Migrate `landlord-dashboard/.github/workflows/run-integration-tests.yml` to use the `:8.0-rs` tag if the existing services-block change ([landlord-dashboard#2356](https://github.com/wunderflats/landlord-dashboard/pull/2356)) turns out to need replica-set mode after all.
- Migrate `api/.github/workflows/run-api-tests.yml`, the two `website` workflows, and the two `jobs` workflows off `supercharge/mongodb-github-action` to a `services:` block backed by this tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)